### PR TITLE
Fixed ModelNotFound specialization

### DIFF
--- a/Sources/APIErrorMiddleware/Specialization/Specialization.swift
+++ b/Sources/APIErrorMiddleware/Specialization/Specialization.swift
@@ -43,15 +43,15 @@ public protocol ErrorCatchingSpecialization {
 /// Catches Fluent's `modelNotFound` error and returns a 404 status code.
 public struct ModelNotFound: ErrorCatchingSpecialization {
     public init() {}
-    
+
     public func convert(error: Error, on request: Request) -> ErrorResult? {
-        if let error = error as? Debuggable, error.identifier == "modelNotFound" {
-            
-            // We have the infamous `modelNotFound` error from Fluent that returns
-            // a 500 status code instead of a 404.
-            // Set the message to the error's `reason` and the status to 404 (Not Found)
+        if
+            let wrappingError = error as? NotFound,
+            let error = wrappingError.rootCause as? FluentError
+        {
             return ErrorResult(message: error.reason, status: .notFound)
         }
+
         return nil
     }
 }


### PR DESCRIPTION
The previous implementation of `ModelNotFound` was not working for me anymore (`fluent 3.0.0-rc.4.0.2` with `fluent 3.0.0-rc.4.0.3`) but these changes seem to make it work again. 