### PR TITLE
Fixed compilation error introduced in PR#1

### DIFF
--- a/Sources/APIErrorMiddleware/APIErrorMiddleware.swift
+++ b/Sources/APIErrorMiddleware/APIErrorMiddleware.swift
@@ -24,7 +24,11 @@ public final class APIErrorMiddleware: Middleware, Service, ServiceType {
     
     /// Creates a service instance. Used by a `ServiceFactory`.
     public static func makeService(for worker: Container) throws -> APIErrorMiddleware {
-        return APIErrorMiddleware(environment: worker.environment, specializations: [ModelNotFound()])
+        #if canImport(Fluent)
+            return APIErrorMiddleware(environment: worker.environment, specializations: [ModelNotFound()])
+        #else
+            return APIErrorMiddleware(environment: worker.environment, specializations: [])
+        #endif
     }
     
     /// Catch all errors thrown by the route handler or

--- a/Sources/APIErrorMiddleware/Specialization/Specialization.swift
+++ b/Sources/APIErrorMiddleware/Specialization/Specialization.swift
@@ -40,6 +40,9 @@ public protocol ErrorCatchingSpecialization {
 
 // MARK: - ErrorCatchingSpecialization implementations
 
+#if canImport(Fluent)
+import Fluent
+
 /// Catches Fluent's `modelNotFound` error and returns a 404 status code.
 public struct ModelNotFound: ErrorCatchingSpecialization {
     public init() {}
@@ -55,3 +58,4 @@ public struct ModelNotFound: ErrorCatchingSpecialization {
         return nil
     }
 }
+#endif


### PR DESCRIPTION
Now `ModelNotFound` is only compiled if `Fluent` can be imported. Solves #3.